### PR TITLE
added template_engine: liquid

### DIFF
--- a/test/fixtures/src/_layouts/default.html
+++ b/test/fixtures/src/_layouts/default.html
@@ -1,4 +1,5 @@
 ---
+template_engine: liquid
 ---
 <html>
   <head>

--- a/test/fixtures/src/index.html
+++ b/test/fixtures/src/index.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+template_engine: liquid
 ---
 
 Testing this plugin: {% sample_plugin %}


### PR DESCRIPTION
The new Bridgetown 2.0 version sets ERB template engine as default.
This sample plugin assumes that liquid is used by default.

So with Bridgetown 2.0 the `bridgetown plugins new XYZ` command creates a plugin where the test fails because ERB template engine as default.

## Steps to reproduce
```bash
bridgetown plugins new XYZ
cd XYZ
rake
```

```text
# Running tests with run options --seed 2676:

FF

Finished tests in 0.114453s, 17.4745 tests/s, 34.9490 assertions/s.


Failure:
TestMyname::Myname#test_0002_outputs the sample Liquid tag [/home/kathi/projects/MYNAME/test/test_myname.rb:32]
Minitest::Assertion: Expected "<html>\n  <head>\n    <title>{{ site.metadata.title }}</title>\n  </head>\n  <body>\n    THIS IS MY LAYOUT\n    {{ content }}\n  </body>\n</html>\n" to include "This plugin works!".

Failure:
TestMyname::Myname#test_0001_outputs the overridden metadata [/home/kathi/projects/MYNAME/test/test_myname.rb:28]
Minitest::Assertion: Expected "<html>\n  <head>\n    <title>{{ site.metadata.title }}</title>\n  </head>\n  <body>\n    THIS IS MY LAYOUT\n    {{ content }}\n  </body>\n</html>\n" to include "<title>My Awesome Site</title>".

2 tests, 4 assertions, 2 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1)
/home/kathi/.gems/gems/rake-13.2.1/exe/rake:27:in `<top (required)>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```
## To fix
I added
```yaml
template_engine: liquid
```
to `fixtures/src/_layouts/default.html` and `fixtures/src/index.html` to make it work again.